### PR TITLE
Use `SimpleHistoryAdmin` for viewing history in admin.

### DIFF
--- a/asset_hound/settings.py
+++ b/asset_hound/settings.py
@@ -50,7 +50,6 @@ INSTALLED_APPS = [
 
     # dependencies
     'corsheaders',
-    'reversion',
     'rest_framework',
     'rest_framework_gis',
     'recurrence',

--- a/assets/admin.py
+++ b/assets/admin.py
@@ -72,42 +72,17 @@ class OrganizationAdmin(SimpleHistoryAdmin):
 
 
 @admin.register(Asset)
-class AssetAdmin(admin.ModelAdmin):
+class AssetAdmin(SimpleHistoryAdmin):
     list_display = (
         'id',
         'name',
         'organization',
-        # 'localizability',
         'location',
-        # 'url',
-        # 'email',
-        # 'phone',
-        # 'hours_of_operation',
-        # 'holiday_hours_of_operation',
-        # 'child_friendly',
-        # 'capacity',
-        # 'internet_access',
-        # 'wifi_network',
-        # 'computers_available',
-        # 'open_to_public',
-        # 'sensitive',
         'date_entered',
         'last_updated',
         'data_source',
         'primary_key_from_rocket',
     )
-    # list_filter = (
-    #     'organization',
-    #     'location',
-    #     'child_friendly',
-    #     'internet_access',
-    #     'computers_available',
-    #     'open_to_public',
-    #     'sensitive',
-    #     'date_entered',
-    #     'last_updated',
-    #     'data_source',
-    # )
     autocomplete_fields = (
         'location',
         'asset_types',

--- a/assets/admin.py
+++ b/assets/admin.py
@@ -1,24 +1,32 @@
 # -*- coding: utf-8 -*-
 from django.contrib import admin
-
-from .models import (
-    AssetType,
-    Tag,
-    Location,
-    Organization,
-    ProvidedService,
-    TargetPopulation,
-    DataSource,
-    Asset,
-    RawAsset,
-    Category
-)
+from simple_history.admin import SimpleHistoryAdmin
+from .models import (AssetType,
+                     Tag,
+                     Location,
+                     Organization,
+                     ProvidedService,
+                     TargetPopulation,
+                     DataSource,
+                     Asset,
+                     RawAsset,
+                     Category)
 
 
 @admin.register(AssetType)
 class AssetTypeAdmin(admin.ModelAdmin):
     list_display = ('id', 'name', 'title', 'category')
     search_fields = ('name',)
+
+
+class AssetTypeInline(admin.TabularInline):
+    model = AssetType
+
+
+@admin.register(Category)
+class CategoryAdmin(admin.ModelAdmin):
+    list_display = ['name', ]
+    search_fields = ['name', ]
 
 
 @admin.register(Tag)
@@ -28,20 +36,13 @@ class TagAdmin(admin.ModelAdmin):
 
 
 @admin.register(Location)
-class LocationAdmin(admin.ModelAdmin):
+class LocationAdmin(SimpleHistoryAdmin):
     list_display = (
         'id',
         'name',
         'geom',
     )
     raw_id_fields = ('parent_location',)
-    search_fields = ('name',)
-
-
-@admin.register(Organization)
-class OrganizationAdmin(admin.ModelAdmin):
-    list_display = ('id', 'name', 'location', 'email', 'phone')
-    list_filter = ('location',)
     search_fields = ('name',)
 
 
@@ -60,6 +61,13 @@ class TargetPopulationAdmin(admin.ModelAdmin):
 @admin.register(DataSource)
 class DataSourceAdmin(admin.ModelAdmin):
     list_display = ('id', 'name', 'url')
+    search_fields = ('name',)
+
+
+@admin.register(Organization)
+class OrganizationAdmin(SimpleHistoryAdmin):
+    list_display = ('id', 'name', 'location', 'email', 'phone')
+    list_filter = ('location',)
     search_fields = ('name',)
 
 
@@ -111,7 +119,7 @@ class AssetAdmin(admin.ModelAdmin):
 
 
 @admin.register(RawAsset)
-class RawAssetAdmin(admin.ModelAdmin):
+class RawAssetAdmin(SimpleHistoryAdmin):
     list_display = (
         'id',
         'name',
@@ -159,13 +167,3 @@ class RawAssetAdmin(admin.ModelAdmin):
         'hard_to_count_population',
     )
     search_fields = ('name', 'street_address', 'city', 'zip_code')
-
-
-class AssetTypeInline(admin.TabularInline):
-    model = AssetType
-
-
-@admin.register(Category)
-class CategoryAdmin(admin.ModelAdmin):
-    list_display = ['name', ]
-    search_fields = ['name', ]

--- a/assets/models.py
+++ b/assets/models.py
@@ -242,7 +242,7 @@ class RawAsset(BaseAsset):
     # will be tracked.
 
 
-#class Asset(BaseAsset): # This is supposed to replace the original Asset class.
+# class Asset(BaseAsset): # This is supposed to replace the original Asset class.
 #    # [ ] After a staging server has been set up, with a duplicate database,
 #    # Check (first when making migrations) that this will not screw everything up.
 #

--- a/assets/models.py
+++ b/assets/models.py
@@ -296,9 +296,7 @@ class Asset(models.Model):
     date_entered = models.DateTimeField(editable=False, auto_now_add=True)
     last_updated = models.DateTimeField(editable=False, auto_now=True)
 
-    history = HistoricalRecords() # This adds a HistoricalAsset table to the database, which
-    # will record a new row every time a tracked change (model creation, change, or deletion)
-    # occurs.
+    history = HistoricalRecords()
 
     @property
     def category(self):


### PR DESCRIPTION
You can explore the history of models being tracked by `django-simple-history` by clicking the `HISTORY` button in the top right corner of a tracked object's admin page.